### PR TITLE
Allow conf to be freed sooner on CONNECT requests.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -193,6 +193,7 @@ func (h proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		fmt.Fprint(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+		conf = nil // Allow it to be garbage-collected, since we won't use it any more.
 		SSLBump(conn, r.URL.Host, user, authUser)
 		return
 	}
@@ -213,6 +214,7 @@ func (h proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		fmt.Fprint(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
 		logAccess(r, nil, 0, false, user, tally, scores, thisRule, "", ignored, userAgent)
+		conf = nil // Allow it to be garbage-collected, since we won't use it any more.
 		connectDirect(conn, r.URL.Host, nil)
 		return
 	}


### PR DESCRIPTION
When Redwood reloads its configuration, it keeps the old configuration
around until all HTTP requests currently in progress have finished.
For CONNECT requests, this is not really necessary, since SSLBump
gets a fresh copy of the configuration.