### PR TITLE
Lowering the connections garbage collection to 15 seconds which makes…

### DIFF
--- a/config.go
+++ b/config.go
@@ -134,7 +134,7 @@ func loadConfiguration() (*config, error) {
 	c.newActiveFlag("categories", "/etc/redwood/categories", "path to configuration files for categories", c.loadCategories)
 	c.flags.DurationVar(&c.CertCache.TTL, "cert-cache-ttl", time.Hour, "how long to cache generated TLS certificates")
 	c.flags.StringVar(&c.CGIBin, "cgi-bin", "", "path to CGI files for built-in web server")
-	c.flags.DurationVar(&c.CloseIdleConnections, "close-idle-connections", time.Hour, "how often to close idle HTTP connections to upstream server")
+	c.flags.DurationVar(&c.CloseIdleConnections, "close-idle-connections", time.Second * 15, "how often to close idle HTTP connections to upstream server")
 	c.newActiveFlag("content-pruning", "", "path to config file for content pruning", c.loadPruningConfig)
 	c.flags.BoolVar(&c.CountOnce, "count-once", false, "count each phrase only once per page")
 	c.flags.IntVar(&c.DhashThreshold, "dhash-threshold", 0, "how many bits can be different in an image's hash to match")


### PR DESCRIPTION
… some sense compared to the 30 seconds keep alive.
I have tested it and it seems that the default hour won't work with youtube and many other sites.
I know the issue with roundtripper transport exits for quite some time and this is the recommended solution from Brad.