### PR TITLE
Make it easier to parse logs with tools like AWK

### DIFF
--- a/log.go
+++ b/log.go
@@ -129,7 +129,7 @@ func listTally(tally map[string]int) string {
 	b := new(bytes.Buffer)
 	for i, rule := range sortedKeys(tally) {
 		if i > 0 {
-			b.WriteString(", ")
+			b.WriteString(" | ")
 		}
 		fmt.Fprint(b, rule, " ", tally[rule])
 	}


### PR DESCRIPTION
Separate tally's with a pipe instead of a comma so that they are better formatted for tools dealing with CSV parsing.
Signed-off-by: Mike Conrad <mike@enxo.co>